### PR TITLE
Update flake8 rules for migration sync

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = {posargs}
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,E741,W503
+ignore = E123,E125,E402,E501,E741,W503
 max-line-length = 160
 builtins = _
-exclude = .git,.tox
+exclude = .git,.tox,tests/unit/compat/


### PR DESCRIPTION
Once we stop syncing collections from ansible/ansible, we can
standardize on these values.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>